### PR TITLE
Keyspace should be an optional parameter when connecting to cluster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,18 @@
             <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/bric3/maven/CqlExecuteMojo.java
+++ b/src/main/java/io/bric3/maven/CqlExecuteMojo.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.maven.model.FileSet;
@@ -102,7 +103,7 @@ public class CqlExecuteMojo extends AbstractMojo {
         }
 
         try (Cluster cluster = cluster();
-             Session session = cluster.connect(keyspace)) {
+             Session session = connectTo(cluster)) {
             cqlFiles(fileset).stream()
                              .flatMap(this::readContent)
                              .flatMap(this::toStatements)
@@ -112,6 +113,13 @@ public class CqlExecuteMojo extends AbstractMojo {
             throw new MojoExecutionException(e.getMessage(), e);
         }
 
+    }
+    
+    Session connectTo(Cluster cluster) {
+        if (Objects.isNull(keyspace) || keyspace.isEmpty()) {
+            return cluster.connect();
+        }
+        return cluster.connect(keyspace);
     }
 
     private void logStatement(String statement) {

--- a/src/test/java/io/bric3/maven/CqlExecuteMojoTest.java
+++ b/src/test/java/io/bric3/maven/CqlExecuteMojoTest.java
@@ -1,0 +1,49 @@
+package io.bric3.maven;
+
+import static org.mockito.Mockito.verify;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import com.datastax.driver.core.Cluster;
+
+public class CqlExecuteMojoTest {
+
+    @Rule
+    public MockitoRule mockito = MockitoJUnit.rule();
+
+    @Mock
+    private Cluster cluster;
+
+    @Test
+    public void should_connect_to_cluster_with_a_keyspace() {
+        CqlExecuteMojo mojo = new CqlExecuteMojo();
+        mojo.keyspace = "keyspace-name";
+
+        mojo.connectTo(cluster);
+
+        verify(cluster).connect("keyspace-name");
+    }
+
+    @Test
+    public void should_connect_to_cluster_without_any_keyspace() {
+        CqlExecuteMojo mojo = new CqlExecuteMojo();
+        mojo.keyspace = null;
+
+        mojo.connectTo(cluster);
+
+        verify(cluster).connect();
+    }
+
+    @Test
+    public void should_connect_to_cluster_without_any_keyspace_when_it_is_empty() {
+        CqlExecuteMojo mojo = new CqlExecuteMojo();
+        mojo.keyspace = "";
+
+        mojo.connectTo(cluster);
+
+        verify(cluster).connect();
+    }
+
+}


### PR DESCRIPTION
Use `Cluster.connect()` instead of `Cluster.connect("")` when `cassandra.keyspace` property is not defined or empty.