### PR TITLE
Fix groupId in the README sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ And you have the following plugin definition :
 
 ```xml
 <plugin>
-    <groupId>com.github.bric3</groupId>
+    <groupId>com.github.bric3.maven</groupId>
     <artifactId>cql-maven-plugin</artifactId>
     <version>0.4</version>
     <configuration>


### PR DESCRIPTION
The sample pom in the README file uses <groupId>com.github.bric3</groupId> instead of <groupId>com.github.bric3.maven</groupId> as found in Maven Central.